### PR TITLE
Simplify Supabase reservations MCP tools

### DIFF
--- a/src/index-noauth.ts
+++ b/src/index-noauth.ts
@@ -1,0 +1,37 @@
+import { McpAgent } from "agents/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAllTools } from "./tools/register-tools";
+
+/**
+ * Lightweight MCP server variant that exposes the database tools without requiring
+ * any authentication. This is useful for local development or trusted environments
+ * where GitHub OAuth is not yet configured.
+ */
+class NoAuthDatabaseMCP extends McpAgent<Env, Record<string, never>, Record<string, never>> {
+        server = new McpServer({
+                name: "PostgreSQL Database MCP Server (No Auth)",
+                version: "1.0.0",
+        });
+
+        async init() {
+                registerAllTools(this.server, this.env);
+        }
+}
+
+export const NoAuthMCP = NoAuthDatabaseMCP;
+
+export default {
+        fetch(request: Request, env: Env, ctx: ExecutionContext) {
+                const url = new URL(request.url);
+
+                if (url.pathname === "/sse" || url.pathname === "/sse/message") {
+                        return NoAuthDatabaseMCP.serveSSE("/sse").fetch(request, env, ctx);
+                }
+
+                if (url.pathname === "/mcp") {
+                        return NoAuthDatabaseMCP.serve("/mcp").fetch(request, env, ctx);
+                }
+
+                return new Response("Not found", { status: 404 });
+        },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { McpAgent } from "agents/mcp";
 import { Props } from "./types";
 import { GitHubHandler } from "./auth/github-handler";
-import { closeDb } from "./database/connection";
 import { registerAllTools } from "./tools/register-tools";
 
 export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
@@ -12,29 +11,10 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 		version: "1.0.0",
 	});
 
-	/**
-	 * Cleanup database connections when Durable Object is shutting down
-	 */
-	async cleanup(): Promise<void> {
-		try {
-			await closeDb();
-			console.log('Database connections closed successfully');
-		} catch (error) {
-			console.error('Error during database cleanup:', error);
-		}
-	}
-
-	/**
-	 * Durable Objects alarm handler - used for cleanup
-	 */
-	async alarm(): Promise<void> {
-		await this.cleanup();
-	}
-
-	async init() {
-		// Register all tools based on user permissions
-		registerAllTools(this.server, this.env, this.props);
-	}
+        async init() {
+                // Register all tools based on user permissions
+                registerAllTools(this.server, this.env, this.props);
+        }
 }
 
 export default new OAuthProvider({

--- a/src/tools/database-tools-sentry.ts
+++ b/src/tools/database-tools-sentry.ts
@@ -1,235 +1,166 @@
 import * as Sentry from "@sentry/cloudflare";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { 
-	Props, 
-	ListTablesSchema, 
-	QueryDatabaseSchema, 
-	ExecuteDatabaseSchema,
-	createErrorResponse,
-	createSuccessResponse
+import {
+        Props,
+        CreateReservationParams,
+        DeleteReservationParams,
+        UpdateReservationParams,
+        createErrorResponse,
+        createSuccessResponse,
+        type McpResponse,
+        type CreateReservationInput,
+        type DeleteReservationInput,
+        type UpdateReservationInput,
 } from "../types";
-import { validateSqlQuery, isWriteOperation, formatDatabaseError } from "../database/security";
-import { withDatabase } from "../database/utils";
-
-const ALLOWED_USERNAMES = new Set<string>([
-	// Add GitHub usernames of users who should have access to database write operations
-	// For example: 'yourusername', 'coworkerusername'
-	'coleam00'
-]);
-
-// Error handling helper for MCP tools with Sentry
-function handleError(error: unknown): { content: Array<{ type: "text"; text: string; isError?: boolean }> } {
-	const eventId = Sentry.captureException(error);
-
-	const errorMessage = [
-		"**Error**",
-		"There was a problem with your request.",
-		"Please report the following to the support team:",
-		`**Event ID**: ${eventId}`,
-		process.env.NODE_ENV !== "production"
-			? error instanceof Error
-				? error.message
-				: String(error)
-			: "",
-	].join("\n\n");
-
-	return {
-		content: [
-			{
-				type: "text",
-				text: errorMessage,
-				isError: true,
-			},
-		],
-	};
-}
+import { createReservation, deleteReservation, updateReservation } from "./reservations-service";
 
 export function registerDatabaseToolsWithSentry(server: McpServer, env: Env, props: Props) {
-	// Tool 1: List Tables - Available to all authenticated users
-	server.tool(
-		"listTables",
-		"Get a list of all tables in the database along with their column information. Use this first to understand the database structure before querying.",
-		ListTablesSchema,
-		async () => {
-			return await Sentry.startNewTrace(async () => {
-				return await Sentry.startSpan({
-					name: "mcp.tool/listTables",
-					attributes: {
-						'mcp.tool.name': 'listTables',
-						'mcp.user.login': props.login,
-					},
-				}, async (span) => {
-					// Set user context
-					Sentry.setUser({
-						username: props.login,
-						email: props.email,
-					});
+        server.tool(
+                "createReservation",
+                "Create a reservation in Supabase using the guest's mobile number, name, number of people, date, time, and optional details.",
+                CreateReservationParams,
+                async (input) =>
+                        runWithSentrySpan("createReservation", props, async () => {
+                                const result = await createReservation(env, input as CreateReservationInput);
 
-					try {
-						return await withDatabase((env as any).DATABASE_URL, async (db) => {
-							// Single query to get all table and column information (using your working query)
-							const columns = await db.unsafe(`
-								SELECT 
-									table_name, 
-									column_name, 
-									data_type, 
-									is_nullable,
-									column_default
-								FROM information_schema.columns 
-								WHERE table_schema = 'public' 
-								ORDER BY table_name, ordinal_position
-							`);
-							
-							// Group columns by table
-							const tableMap = new Map();
-							for (const col of columns) {
-								// Use snake_case property names as returned by the SQL query
-								if (!tableMap.has(col.table_name)) {
-									tableMap.set(col.table_name, {
-										name: col.table_name,
-										schema: 'public',
-										columns: []
-									});
-								}
-								tableMap.get(col.table_name).columns.push({
-									name: col.column_name,
-									type: col.data_type,
-									nullable: col.is_nullable === 'YES',
-									default: col.column_default
-								});
-							}
-							
-							const tableInfo = Array.from(tableMap.values());
-							
-							return {
-								content: [
-									{
-										type: "text",
-										text: `**Database Tables and Schema**\n\n${JSON.stringify(tableInfo, null, 2)}\n\n**Total tables found:** ${tableInfo.length}\n\n**Note:** Use the \`queryDatabase\` tool to run SELECT queries, or \`executeDatabase\` tool for write operations (if you have write access).`
-									}
-								]
-							};
-						});
-					} catch (error) {
-						console.error('listTables error:', error);
-						span.setStatus({ code: 2 }); // error
-						return handleError(error);
-					}
-				});
-			});
-		}
-	);
+                                if (!result.success) {
+                                        return sentryErrorResponse(
+                                                `Failed to create reservation: ${result.error}`,
+                                                result.data
+                                        );
+                                }
 
-	// Tool 2: Query Database - Available to all authenticated users (read-only)
-	server.tool(
-		"queryDatabase",
-		"Execute a read-only SQL query against the PostgreSQL database. This tool only allows SELECT statements and other read operations. All authenticated users can use this tool.",
-		QueryDatabaseSchema,
-		async ({ sql }) => {
-			return await Sentry.startNewTrace(async () => {
-				return await Sentry.startSpan({
-					name: "mcp.tool/queryDatabase",
-					attributes: {
-						'mcp.tool.name': 'queryDatabase',
-						'mcp.user.login': props.login,
-						'mcp.sql.query': sql.substring(0, 100), // Truncate for security
-					},
-				}, async (span) => {
-					// Set user context
-					Sentry.setUser({
-						username: props.login,
-						email: props.email,
-					});
+                                const created = Array.isArray(result.data) ? result.data[0] : result.data;
 
-					try {
-						// Validate the SQL query
-						const validation = validateSqlQuery(sql);
-						if (!validation.isValid) {
-							return createErrorResponse(`Invalid SQL query: ${validation.error}`);
-						}
-						
-						// Check if it's a write operation
-						if (isWriteOperation(sql)) {
-							return createErrorResponse(
-								"Write operations are not allowed with this tool. Use the `executeDatabase` tool if you have write permissions (requires special GitHub username access)."
-							);
-						}
-						
-						return await withDatabase((env as any).DATABASE_URL, async (db) => {
-							const results = await db.unsafe(sql);
-							
-							return {
-								content: [
-									{
-										type: "text",
-										text: `**Query Results**\n\`\`\`sql\n${sql}\n\`\`\`\n\n**Results:**\n\`\`\`json\n${JSON.stringify(results, null, 2)}\n\`\`\`\n\n**Rows returned:** ${Array.isArray(results) ? results.length : 1}`
-									}
-								]
-							};
-						});
-					} catch (error) {
-						console.error('queryDatabase error:', error);
-						span.setStatus({ code: 2 }); // error
-						return handleError(error);
-					}
-				});
-			});
-		}
-	);
+                                if (!created) {
+                                        return sentryErrorResponse(
+                                                "Supabase returned no data after creating the reservation."
+                                        );
+                                }
 
-	// Tool 3: Execute Database - Only available to privileged users (write operations)
-	if (ALLOWED_USERNAMES.has(props.login)) {
-		server.tool(
-			"executeDatabase",
-			"Execute any SQL statement against the PostgreSQL database, including INSERT, UPDATE, DELETE, and DDL operations. This tool is restricted to specific GitHub users and can perform write transactions. **USE WITH CAUTION** - this can modify or delete data.",
-			ExecuteDatabaseSchema,
-			async ({ sql }) => {
-				return await Sentry.startNewTrace(async () => {
-					return await Sentry.startSpan({
-						name: "mcp.tool/executeDatabase",
-						attributes: {
-							'mcp.tool.name': 'executeDatabase',
-							'mcp.user.login': props.login,
-							'mcp.sql.query': sql.substring(0, 100), // Truncate for security
-							'mcp.sql.is_write': isWriteOperation(sql),
-						},
-					}, async (span) => {
-						// Set user context
-						Sentry.setUser({
-							username: props.login,
-							email: props.email,
-						});
+                                return createSuccessResponse(
+                                        `Created reservation for ${created.name ?? "guest"} on ${created.date ?? "unknown date"} at ${created.time ?? "unknown time"}.`,
+                                        created
+                                );
+                        })
+        );
 
-						try {
-							// Validate the SQL query
-							const validation = validateSqlQuery(sql);
-							if (!validation.isValid) {
-								return createErrorResponse(`Invalid SQL statement: ${validation.error}`);
-							}
-							
-							return await withDatabase((env as any).DATABASE_URL, async (db) => {
-								const results = await db.unsafe(sql);
-								
-								const isWrite = isWriteOperation(sql);
-								const operationType = isWrite ? "Write Operation" : "Read Operation";
-								
-								return {
-									content: [
-										{
-											type: "text",
-											text: `**${operationType} Executed Successfully**\n\`\`\`sql\n${sql}\n\`\`\`\n\n**Results:**\n\`\`\`json\n${JSON.stringify(results, null, 2)}\n\`\`\`\n\n${isWrite ? '**⚠️ Database was modified**' : `**Rows returned:** ${Array.isArray(results) ? results.length : 1}`}\n\n**Executed by:** ${props.login} (${props.name})`
-										}
-									]
-								};
-							});
-						} catch (error) {
-							console.error('executeDatabase error:', error);
-							span.setStatus({ code: 2 }); // error
-							return handleError(error);
-						}
-					});
-				});
-			}
-		);
-	}
+        server.tool(
+                "updateReservation",
+                "Update a reservation by matching the current guest name and mobile number, then setting new details such as time, party size, or notes.",
+                UpdateReservationParams,
+                async (input) =>
+                        runWithSentrySpan("updateReservation", props, async () => {
+                                const result = await updateReservation(env, input as UpdateReservationInput);
+
+                                if (!result.success) {
+                                        return sentryErrorResponse(
+                                                `Failed to update the reservation for ${input?.name ?? "unknown guest"} (${input?.mobile ?? "unknown mobile"}): ${result.error}`,
+                                                result.data
+                                        );
+                                }
+
+                                const updated = Array.isArray(result.data) ? result.data[0] : result.data;
+
+                                if (!updated) {
+                                        return sentryErrorResponse(
+                                                `No reservation for ${input?.name ?? "unknown guest"} (${input?.mobile ?? "unknown mobile"}) was updated. It may not exist.`,
+                                                result.data
+                                        );
+                                }
+
+                                const changedFields = countChangedFields(input as UpdateReservationInput);
+
+                                return createSuccessResponse(
+                                        `Updated reservation for ${updated.name ?? input?.name ?? "guest"} (${updated.mobile ?? input?.mobile ?? "mobile"}). ${changedFields} field${changedFields === 1 ? "" : "s"} changed.`,
+                                        updated
+                                );
+                        })
+        );
+
+        server.tool(
+                "deleteReservation",
+                "Delete a reservation by providing the guest's name and mobile number.",
+                DeleteReservationParams,
+                async (input) =>
+                        runWithSentrySpan("deleteReservation", props, async () => {
+                                const result = await deleteReservation(env, input as DeleteReservationInput);
+
+                                if (!result.success) {
+                                        return sentryErrorResponse(
+                                                `Failed to delete the reservation for ${input?.name ?? "unknown guest"} (${input?.mobile ?? "unknown mobile"}): ${result.error}`,
+                                                result.data
+                                        );
+                                }
+
+                                const deleted = Array.isArray(result.data) ? result.data[0] : result.data;
+
+                                if (!deleted) {
+                                        return sentryErrorResponse(
+                                                `No reservation for ${input?.name ?? "unknown guest"} (${input?.mobile ?? "unknown mobile"}) was deleted. It may not exist.`,
+                                                result.data
+                                        );
+                                }
+
+                                return createSuccessResponse(
+                                        `Deleted reservation for ${deleted.name ?? input?.name ?? "guest"} (${deleted.mobile ?? input?.mobile ?? "mobile"}).`,
+                                        deleted
+                                );
+                        })
+        );
+}
+
+async function runWithSentrySpan(
+        toolName: string,
+        props: Props,
+        handler: () => Promise<McpResponse>
+) {
+        return Sentry.startNewTrace(async () => {
+                return Sentry.startSpan(
+                        {
+                                name: `mcp.tool/${toolName}`,
+                                attributes: {
+                                        "mcp.tool.name": toolName,
+                                        "mcp.user.login": props.login,
+                                },
+                        },
+                        async (span) => {
+                                Sentry.setUser({
+                                        username: props.login,
+                                        email: props.email,
+                                });
+
+                                try {
+                                        const response = await handler();
+                                        return response;
+                                } catch (error) {
+                                        return sentryErrorResponse(error);
+                                } finally {
+                                        span.end();
+                                }
+                        }
+                );
+        });
+}
+
+function sentryErrorResponse(message: unknown, details?: unknown) {
+        const eventId = Sentry.captureException(
+                message instanceof Error ? message : new Error(String(message))
+        );
+
+        if (typeof message === "string") {
+                return createErrorResponse(`${message}\n\n**Event ID:** ${eventId}`, details);
+        }
+
+        const text = message instanceof Error ? message.message : String(message);
+        return createErrorResponse(`Unexpected error: ${text}\n\n**Event ID:** ${eventId}`, details);
+}
+
+function countChangedFields(input: UpdateReservationInput): number {
+        const ignoredKeys = new Set(["mobile", "name"]);
+
+        return Object.entries(input)
+                .filter(([key]) => !ignoredKeys.has(key))
+                .filter(([, value]) => value !== undefined)
+                .length;
 }

--- a/src/tools/database-tools.ts
+++ b/src/tools/database-tools.ts
@@ -1,155 +1,122 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { 
-	Props, 
-	ListTablesSchema, 
-	QueryDatabaseSchema, 
-	ExecuteDatabaseSchema,
-	createErrorResponse,
-	createSuccessResponse
+import {
+        Props,
+        CreateReservationParams,
+        DeleteReservationParams,
+        UpdateReservationParams,
+        createErrorResponse,
+        createSuccessResponse,
+        type CreateReservationInput,
+        type DeleteReservationInput,
+        type UpdateReservationInput,
 } from "../types";
-import { validateSqlQuery, isWriteOperation, formatDatabaseError } from "../database/security";
-import { withDatabase } from "../database/utils";
+import { createReservation, deleteReservation, updateReservation } from "./reservations-service";
 
-const ALLOWED_USERNAMES = new Set<string>([
-	// Add GitHub usernames of users who should have access to database write operations
-	// For example: 'yourusername', 'coworkerusername'
-	'coleam00'
-]);
+export type DatabaseToolsOptions = Record<string, never>;
 
-export function registerDatabaseTools(server: McpServer, env: Env, props: Props) {
-	// Tool 1: List Tables - Available to all authenticated users
-	server.tool(
-		"listTables",
-		"Get a list of all tables in the database along with their column information. Use this first to understand the database structure before querying.",
-		ListTablesSchema,
-		async () => {
-			try {
-				return await withDatabase((env as any).DATABASE_URL, async (db) => {
-					// Single query to get all table and column information (using your working query)
-					const columns = await db.unsafe(`
-						SELECT 
-							table_name, 
-							column_name, 
-							data_type, 
-							is_nullable,
-							column_default
-						FROM information_schema.columns 
-						WHERE table_schema = 'public' 
-						ORDER BY table_name, ordinal_position
-					`);
-					
-					// Group columns by table
-					const tableMap = new Map();
-					for (const col of columns) {
-						// Use snake_case property names as returned by the SQL query
-						if (!tableMap.has(col.table_name)) {
-							tableMap.set(col.table_name, {
-								name: col.table_name,
-								schema: 'public',
-								columns: []
-							});
-						}
-						tableMap.get(col.table_name).columns.push({
-							name: col.column_name,
-							type: col.data_type,
-							nullable: col.is_nullable === 'YES',
-							default: col.column_default
-						});
-					}
-					
-					const tableInfo = Array.from(tableMap.values());
-					
-					return {
-						content: [
-							{
-								type: "text",
-								text: `**Database Tables and Schema**\n\n${JSON.stringify(tableInfo, null, 2)}\n\n**Total tables found:** ${tableInfo.length}\n\n**Note:** Use the \`queryDatabase\` tool to run SELECT queries, or \`executeDatabase\` tool for write operations (if you have write access).`
-							}
-						]
-					};
-				});
-			} catch (error) {
-				console.error('listTables error:', error);
-				return createErrorResponse(
-					`Error retrieving database schema: ${formatDatabaseError(error)}`
-				);
-			}
-		}
-	);
+export function registerDatabaseTools(
+        server: McpServer,
+        env: Env,
+        _props?: Props,
+        _options: DatabaseToolsOptions = {}
+) {
+        server.tool(
+                "createReservation",
+                "Create a reservation in Supabase using the guest's mobile number, name, number of people, date, time, and optional details.",
+                CreateReservationParams,
+                async (input) => {
+                        const result = await createReservation(env, input as CreateReservationInput);
 
-	// Tool 2: Query Database - Available to all authenticated users (read-only)
-	server.tool(
-		"queryDatabase",
-		"Execute a read-only SQL query against the PostgreSQL database. This tool only allows SELECT statements and other read operations. All authenticated users can use this tool.",
-		QueryDatabaseSchema,
-		async ({ sql }) => {
-			try {
-				// Validate the SQL query
-				const validation = validateSqlQuery(sql);
-				if (!validation.isValid) {
-					return createErrorResponse(`Invalid SQL query: ${validation.error}`);
-				}
-				
-				// Check if it's a write operation
-				if (isWriteOperation(sql)) {
-					return createErrorResponse(
-						"Write operations are not allowed with this tool. Use the `executeDatabase` tool if you have write permissions (requires special GitHub username access)."
-					);
-				}
-				
-				return await withDatabase((env as any).DATABASE_URL, async (db) => {
-					const results = await db.unsafe(sql);
-					
-					return {
-						content: [
-							{
-								type: "text",
-								text: `**Query Results**\n\`\`\`sql\n${sql}\n\`\`\`\n\n**Results:**\n\`\`\`json\n${JSON.stringify(results, null, 2)}\n\`\`\`\n\n**Rows returned:** ${Array.isArray(results) ? results.length : 1}`
-							}
-						]
-					};
-				});
-			} catch (error) {
-				console.error('queryDatabase error:', error);
-				return createErrorResponse(`Database query error: ${formatDatabaseError(error)}`);
-			}
-		}
-	);
+                        if (!result.success) {
+                                return createErrorResponse(
+                                        `Failed to create reservation: ${result.error}`,
+                                        result.data
+                                );
+                        }
 
-	// Tool 3: Execute Database - Only available to privileged users (write operations)
-	if (ALLOWED_USERNAMES.has(props.login)) {
-		server.tool(
-			"executeDatabase",
-			"Execute any SQL statement against the PostgreSQL database, including INSERT, UPDATE, DELETE, and DDL operations. This tool is restricted to specific GitHub users and can perform write transactions. **USE WITH CAUTION** - this can modify or delete data.",
-			ExecuteDatabaseSchema,
-			async ({ sql }) => {
-				try {
-					// Validate the SQL query
-					const validation = validateSqlQuery(sql);
-					if (!validation.isValid) {
-						return createErrorResponse(`Invalid SQL statement: ${validation.error}`);
-					}
-					
-					return await withDatabase((env as any).DATABASE_URL, async (db) => {
-						const results = await db.unsafe(sql);
-						
-						const isWrite = isWriteOperation(sql);
-						const operationType = isWrite ? "Write Operation" : "Read Operation";
-						
-						return {
-							content: [
-								{
-									type: "text",
-									text: `**${operationType} Executed Successfully**\n\`\`\`sql\n${sql}\n\`\`\`\n\n**Results:**\n\`\`\`json\n${JSON.stringify(results, null, 2)}\n\`\`\`\n\n${isWrite ? '**⚠️ Database was modified**' : `**Rows returned:** ${Array.isArray(results) ? results.length : 1}`}\n\n**Executed by:** ${props.login} (${props.name})`
-								}
-							]
-						};
-					});
-				} catch (error) {
-					console.error('executeDatabase error:', error);
-					return createErrorResponse(`Database execution error: ${formatDatabaseError(error)}`);
-				}
-			}
-		);
-	}
+                        const created = Array.isArray(result.data) ? result.data[0] : result.data;
+
+                        if (!created) {
+                                return createErrorResponse(
+                                        "Supabase returned no data after creating the reservation."
+                                );
+                        }
+
+                        return createSuccessResponse(
+                                `Created reservation for ${created.name ?? "guest"} on ${created.date ?? "unknown date"} at ${created.time ?? "unknown time"}.`,
+                                created
+                        );
+                }
+        );
+
+        server.tool(
+                "updateReservation",
+                "Update a reservation by matching the current guest name and mobile number, then setting new details such as time, party size, or notes.",
+                UpdateReservationParams,
+                async (input) => {
+                        const result = await updateReservation(env, input as UpdateReservationInput);
+
+                        if (!result.success) {
+                                return createErrorResponse(
+                                        `Failed to update the reservation for ${input?.name ?? "unknown guest"} (${input?.mobile ?? "unknown mobile"}): ${result.error}`,
+                                        result.data
+                                );
+                        }
+
+                        const updated = Array.isArray(result.data) ? result.data[0] : result.data;
+
+                        if (!updated) {
+                                return createErrorResponse(
+                                        `No reservation for ${input?.name ?? "unknown guest"} (${input?.mobile ?? "unknown mobile"}) was updated. It may not exist.`,
+                                        result.data
+                                );
+                        }
+
+                        const changedFields = countChangedFields(input as UpdateReservationInput);
+
+                        return createSuccessResponse(
+                                `Updated reservation for ${updated.name ?? input?.name ?? "guest"} (${updated.mobile ?? input?.mobile ?? "mobile"}). ${changedFields} field${changedFields === 1 ? "" : "s"} changed.`,
+                                updated
+                        );
+                }
+        );
+
+        server.tool(
+                "deleteReservation",
+                "Delete a reservation by providing the guest's name and mobile number.",
+                DeleteReservationParams,
+                async (input) => {
+                        const result = await deleteReservation(env, input as DeleteReservationInput);
+
+                        if (!result.success) {
+                                return createErrorResponse(
+                                        `Failed to delete the reservation for ${input?.name ?? "unknown guest"} (${input?.mobile ?? "unknown mobile"}): ${result.error}`,
+                                        result.data
+                                );
+                        }
+
+                        const deleted = Array.isArray(result.data) ? result.data[0] : result.data;
+
+                        if (!deleted) {
+                                return createErrorResponse(
+                                        `No reservation for ${input?.name ?? "unknown guest"} (${input?.mobile ?? "unknown mobile"}) was deleted. It may not exist.`,
+                                        result.data
+                                );
+                        }
+
+                        return createSuccessResponse(
+                                `Deleted reservation for ${deleted.name ?? input?.name ?? "guest"} (${deleted.mobile ?? input?.mobile ?? "mobile"}).`,
+                                deleted
+                        );
+                }
+        );
+}
+
+function countChangedFields(input: UpdateReservationInput): number {
+        const ignoredKeys = new Set(["mobile", "name"]);
+
+        return Object.entries(input)
+                .filter(([key]) => !ignoredKeys.has(key))
+                .filter(([, value]) => value !== undefined)
+                .length;
 }

--- a/src/tools/register-tools.ts
+++ b/src/tools/register-tools.ts
@@ -1,14 +1,23 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Props } from "../types";
-import { registerDatabaseTools } from "./database-tools";
+import { DatabaseToolsOptions, registerDatabaseTools } from "./database-tools";
+
+export interface RegisterToolsOptions {
+        database?: DatabaseToolsOptions;
+}
 
 /**
  * Register all MCP tools based on user permissions
  */
-export function registerAllTools(server: McpServer, env: Env, props: Props) {
-	// Register database tools
-	registerDatabaseTools(server, env, props);
-	
-	// Future tools can be registered here
-	// registerOtherTools(server, env, props);
+export function registerAllTools(
+        server: McpServer,
+        env: Env,
+        props?: Props,
+        options: RegisterToolsOptions = {}
+) {
+        // Register database tools
+        registerDatabaseTools(server, env, props, options.database);
+
+        // Future tools can be registered here
+        // registerOtherTools(server, env, props);
 }

--- a/src/tools/reservations-service.ts
+++ b/src/tools/reservations-service.ts
@@ -1,0 +1,177 @@
+import {
+        CreateReservationSchema,
+        DeleteReservationSchema,
+        UpdateReservationSchema,
+        type CreateReservationInput,
+        type DeleteReservationInput,
+        type UpdateReservationInput,
+        type DatabaseOperationResult,
+} from "../types";
+
+const RESERVATIONS_ENDPOINT = "reservations";
+
+type SupabaseRequestInit = Omit<RequestInit, "body" | "headers"> & {
+        body?: unknown;
+        headers?: HeadersInit;
+        prefer?: string[];
+};
+
+type SupabaseConfig = {
+        url: string;
+        key: string;
+};
+
+function getSupabaseConfig(env: Env): SupabaseConfig {
+        const url = (env as any).SUPABASE_URL as string | undefined;
+        const key = (env as any).SUPABASE_SERVICE_ROLE_KEY as string | undefined;
+
+        if (!url) {
+                throw new Error("SUPABASE_URL is not configured in the worker environment");
+        }
+
+        if (!key) {
+                throw new Error("SUPABASE_SERVICE_ROLE_KEY is not configured in the worker environment");
+        }
+
+        return { url: url.replace(/\/$/, ""), key };
+}
+
+async function supabaseRequest<T>(
+        env: Env,
+        path: string,
+        init: SupabaseRequestInit
+): Promise<DatabaseOperationResult<T>> {
+        const start = Date.now();
+
+        try {
+                const config = getSupabaseConfig(env);
+                const { prefer, body, headers, ...rest } = init;
+                const url = new URL(path, `${config.url}/rest/v1/`);
+
+                const requestHeaders = new Headers(headers ?? {});
+                requestHeaders.set("apikey", config.key);
+                requestHeaders.set("Authorization", `Bearer ${config.key}`);
+
+                if (body !== undefined) {
+                        requestHeaders.set("Content-Type", "application/json");
+                }
+
+                if (prefer?.length) {
+                        requestHeaders.set("Prefer", prefer.join(","));
+                }
+
+                const requestInit: RequestInit = {
+                        ...rest,
+                        headers: requestHeaders,
+                        body: body === undefined ? undefined : (JSON.stringify(body) as BodyInit),
+                };
+
+                const response = await fetch(url, requestInit);
+                const duration = Date.now() - start;
+
+                const text = await response.text();
+                const hasText = text.length > 0;
+                let data: any = undefined;
+
+                if (hasText) {
+                        try {
+                                data = JSON.parse(text);
+                        } catch (error) {
+                                data = text;
+                        }
+                }
+
+                if (!response.ok) {
+                        const errorMessage = typeof data === "object" && data !== null ? data.message ?? response.statusText : response.statusText;
+
+                        return {
+                                success: false,
+                                error: errorMessage,
+                                data: typeof data === "object" && data !== null ? data : undefined,
+                                duration,
+                        };
+                }
+
+                return {
+                        success: true,
+                        data: data as T,
+                        duration,
+                };
+        } catch (error) {
+                return {
+                        success: false,
+                        error: error instanceof Error ? error.message : String(error),
+                };
+        }
+}
+
+function normalizeReservationPayload<T extends Partial<CreateReservationInput>>(payload: T): T {
+        const normalized = { ...payload } as Record<string, unknown>;
+
+        if (normalized.nb_people !== undefined) {
+                normalized.nb_people = Number(normalized.nb_people);
+        }
+
+        return normalized as T;
+}
+
+export async function createReservation(
+        env: Env,
+        payload: CreateReservationInput
+): Promise<DatabaseOperationResult<any[]>> {
+        const parsedPayload = CreateReservationSchema.parse(payload);
+        return supabaseRequest<any[]>(env, RESERVATIONS_ENDPOINT, {
+                method: "POST",
+                body: [normalizeReservationPayload(parsedPayload)],
+                prefer: ["return=representation"],
+        });
+}
+
+export async function updateReservation(
+        env: Env,
+        payload: UpdateReservationInput
+): Promise<DatabaseOperationResult<any[]>> {
+        const parsedPayload = UpdateReservationSchema.parse(payload);
+        const { mobile, name, new_mobile, new_name, ...fields } = parsedPayload;
+
+        const updates = Object.fromEntries(
+                Object.entries(
+                        normalizeReservationPayload({
+                                ...fields,
+                                ...(new_mobile !== undefined ? { mobile: new_mobile } : {}),
+                                ...(new_name !== undefined ? { name: new_name } : {}),
+                        })
+                ).filter(([, value]) => value !== undefined)
+        );
+
+        const encodedMobile = encodeURIComponent(mobile);
+        const encodedName = encodeURIComponent(name);
+
+        return supabaseRequest<any[]>(
+                env,
+                `${RESERVATIONS_ENDPOINT}?mobile=eq.${encodedMobile}&name=eq.${encodedName}`,
+                {
+                        method: "PATCH",
+                        body: updates,
+                        prefer: ["return=representation"],
+                }
+        );
+}
+
+export async function deleteReservation(
+        env: Env,
+        payload: DeleteReservationInput
+): Promise<DatabaseOperationResult<any[]>> {
+        const parsedPayload = DeleteReservationSchema.parse(payload);
+        const encodedMobile = encodeURIComponent(parsedPayload.mobile);
+        const encodedName = encodeURIComponent(parsedPayload.name);
+
+        return supabaseRequest<any[]>(
+                env,
+                `${RESERVATIONS_ENDPOINT}?mobile=eq.${encodedMobile}&name=eq.${encodedName}`,
+                {
+                        method: "DELETE",
+                        prefer: ["return=representation"],
+                }
+        );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,31 +52,119 @@ export interface ParsedApprovalResult {
   headers: Record<string, string>;
 }
 
-// MCP tool schemas using Zod
-export const ListTablesSchema = {};
+// MCP tool schemas for reservation management
+const mobileField = z
+  .string()
+  .min(1, "Mobile number is required")
+  .describe("Customer mobile phone number, including country code if applicable.");
 
-export const QueryDatabaseSchema = {
-  sql: z
-    .string()
-    .min(1, "SQL query cannot be empty")
-    .describe("SQL query to execute (SELECT queries only)"),
+const nameField = z
+  .string()
+  .min(1, "Name is required")
+  .describe("Full name of the guest who made the reservation.");
+
+const nbPeopleField = z
+  .coerce.number()
+  .int("The number of people must be an integer")
+  .min(1, "At least one person must be included in the reservation")
+  .describe("Number of guests included in the reservation.");
+
+const emailField = z
+  .string()
+  .email("Please provide a valid email address")
+  .describe("Contact email address for the reservation.")
+  .optional();
+
+const dateField = z
+  .string()
+  .min(1, "Reservation date is required")
+  .describe("Reservation date in YYYY-MM-DD format.");
+
+const timeField = z
+  .string()
+  .min(1, "Reservation time is required")
+  .describe("Reservation time in HH:MM format (24-hour clock).");
+
+const notesField = z
+  .string()
+  .max(2000, "Notes should be 2000 characters or fewer")
+  .describe("Additional notes or special requests for the reservation.")
+  .optional();
+
+export const CreateReservationSchema = z.object({
+  mobile: mobileField,
+  name: nameField,
+  nb_people: nbPeopleField,
+  date: dateField,
+  time: timeField,
+  email: emailField,
+  notes: notesField,
+});
+
+export const CreateReservationParams = CreateReservationSchema.shape;
+
+const updateOnlyFields = {
+  new_mobile: mobileField.optional().describe(
+    "New mobile number to store for the reservation."
+  ),
+  new_name: nameField.optional().describe(
+    "New guest name to store for the reservation."
+  ),
+  nb_people: nbPeopleField.optional(),
+  email: emailField,
+  date: dateField.optional(),
+  time: timeField.optional(),
+  notes: notesField,
 };
 
-export const ExecuteDatabaseSchema = {
-  sql: z
-    .string()
-    .min(1, "SQL command cannot be empty")
-    .describe("SQL command to execute (INSERT, UPDATE, DELETE, CREATE, etc.)"),
-};
+export const UpdateReservationSchema = z
+  .object({
+    mobile: mobileField.describe(
+      "Current mobile number on the reservation you want to update."
+    ),
+    name: nameField.describe(
+      "Current guest name on the reservation you want to update."
+    ),
+    ...updateOnlyFields,
+  })
+  .refine(
+    (data) =>
+      Object.keys(updateOnlyFields).some(
+        (key) => (data as Record<string, unknown>)[key] !== undefined
+      ),
+    {
+      message: "Provide at least one field to update (new contact info, date, time, etc.).",
+      path: ["mobile"],
+    }
+  );
+
+export const UpdateReservationParams = UpdateReservationSchema.shape;
+
+export const DeleteReservationSchema = z.object({
+  mobile: mobileField.describe(
+    "Mobile number stored on the reservation you want to remove."
+  ),
+  name: nameField.describe(
+    "Guest name stored on the reservation you want to remove."
+  ),
+});
+
+export const DeleteReservationParams = DeleteReservationSchema.shape;
+
+export type CreateReservationInput = z.infer<typeof CreateReservationSchema>;
+export type UpdateReservationInput = z.infer<typeof UpdateReservationSchema>;
+export type DeleteReservationInput = z.infer<typeof DeleteReservationSchema>;
 
 // MCP response types
 export interface McpTextContent {
+  [key: string]: unknown;
   type: "text";
   text: string;
   isError?: boolean;
 }
 
 export interface McpResponse {
+  [key: string]: unknown;
   content: McpTextContent[];
 }
 

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -7,7 +7,8 @@ declare namespace Cloudflare {
 		GITHUB_CLIENT_ID: string;
 		GITHUB_CLIENT_SECRET: string;
 		COOKIE_ENCRYPTION_KEY: string;
-		DATABASE_URL: string;
+                SUPABASE_URL: string;
+                SUPABASE_SERVICE_ROLE_KEY: string;
 		PERPLEXITY_API_KEY: string;
 		ANTHROPIC_API_KEY: string;
 		SENTRY_DSN: string;

--- a/wrangler-noauth.jsonc
+++ b/wrangler-noauth.jsonc
@@ -1,0 +1,27 @@
+{
+  "name": "database-mcp-noauth",
+  "main": "src/index-noauth.ts",
+  "compatibility_date": "2025-03-10",
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
+  "migrations": [
+    {
+      "new_sqlite_classes": [
+        "NoAuthMCP"
+      ],
+      "tag": "v1"
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "class_name": "NoAuthMCP",
+        "name": "MCP_OBJECT"
+      }
+    ]
+  },
+  "dev": {
+    "port": 8793
+  }
+}


### PR DESCRIPTION
## Summary
- update the reservation schemas to require name and mobile, allow optional email/notes, and support updating contact info via new fields
- adjust the Supabase service and both tool registries to target reservations by guest name and mobile number while removing the unused list tool and auth gating
- refresh the README and no-auth entry point to document the create/update/delete-only workflow and optional Supabase email column

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2b9dafb188328a5df6c83a8278f89