### PR TITLE
Add reservation lookup tool for Supabase

### DIFF
--- a/src/tools/reservations-service.ts
+++ b/src/tools/reservations-service.ts
@@ -1,9 +1,11 @@
 import {
         CreateReservationSchema,
         DeleteReservationSchema,
+        GetReservationSchema,
         UpdateReservationSchema,
         type CreateReservationInput,
         type DeleteReservationInput,
+        type GetReservationInput,
         type UpdateReservationInput,
         type DatabaseOperationResult,
 } from "../types";
@@ -174,4 +176,29 @@ export async function deleteReservation(
                         prefer: ["return=representation"],
                 }
         );
+}
+
+export async function getReservation(
+        env: Env,
+        payload: GetReservationInput
+): Promise<DatabaseOperationResult<any[]>> {
+        const parsedPayload = GetReservationSchema.parse(payload);
+        const filters = [
+                `mobile=eq.${encodeURIComponent(parsedPayload.mobile)}`,
+                `name=eq.${encodeURIComponent(parsedPayload.name)}`,
+        ];
+
+        if (parsedPayload.date) {
+                filters.push(`date=eq.${encodeURIComponent(parsedPayload.date)}`);
+        }
+
+        if (parsedPayload.time) {
+                filters.push(`time=eq.${encodeURIComponent(parsedPayload.time)}`);
+        }
+
+        const query = [`select=*`, ...filters].join("&");
+
+        return supabaseRequest<any[]>(env, `${RESERVATIONS_ENDPOINT}?${query}`, {
+                method: "GET",
+        });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,9 +100,29 @@ export const DeleteReservationSchema = z.object({
 
 export const DeleteReservationParams = DeleteReservationSchema.shape;
 
+export const GetReservationSchema = z.object({
+  mobile: mobileField.describe(
+    "Mobile number stored on the reservation you want to find."
+  ),
+  name: nameField.describe(
+    "Guest name stored on the reservation you want to find."
+  ),
+  date: dateField
+    .optional()
+    .describe(
+      "Specific reservation date to filter by (optional, YYYY-MM-DD)."
+    ),
+  time: timeField
+    .optional()
+    .describe("Specific reservation time to filter by (optional, HH:MM)."),
+});
+
+export const GetReservationParams = GetReservationSchema.shape;
+
 export type CreateReservationInput = z.infer<typeof CreateReservationSchema>;
 export type UpdateReservationInput = z.infer<typeof UpdateReservationSchema>;
 export type DeleteReservationInput = z.infer<typeof DeleteReservationSchema>;
+export type GetReservationInput = z.infer<typeof GetReservationSchema>;
 
 // MCP response types
 export interface McpTextContent {


### PR DESCRIPTION
## Summary
- add Supabase reservation lookup service function with optional date and time filters
- register a getReservation MCP tool and tailor success and error responses
- expand unit coverage to validate lookup success, failure, and no-match scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e515427c3483289d790b70f76a12a2